### PR TITLE
10:create-responsive-dialog

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -125,3 +125,10 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}

--- a/src/components/responsive-dialog.tsx
+++ b/src/components/responsive-dialog.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useIsMobile } from "@/hooks/use-mobile";
+import React from "react";
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "./ui/drawer";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog";
+
+interface ResponsiveDialogProps {
+    title: string;
+    description: string;
+    children: React.ReactNode;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+const ResponsiveDialog = ({
+    title,
+    description,
+    children,
+    open,
+    onOpenChange
+}: ResponsiveDialogProps) => {
+    const isMobile = useIsMobile();
+
+    if (isMobile) {
+        return (
+            <Drawer open={open} onOpenChange={onOpenChange}>
+                <DrawerContent>
+                    <DrawerHeader>
+                        <DrawerTitle>{title}</DrawerTitle>
+                        <DrawerDescription>{description}</DrawerDescription>
+                    </DrawerHeader>
+                    <div className="p-4">
+                        {children}
+                    </div>
+                </DrawerContent>
+            </Drawer>
+        );
+    }
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle>{title}</DialogTitle>
+                <DialogDescription>{description}</DialogDescription>
+            </DialogHeader>
+            {children}
+        </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ResponsiveDialog

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -12,6 +12,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { useIsMobile } from "@/hooks/use-mobile"
+import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from "./drawer"
 
 function Command({
   className,
@@ -42,6 +44,55 @@ function CommandDialog({
   className?: string
   showCloseButton?: boolean
 }) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandResponsiveDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Drawer {...props}>
+      <DrawerContent className="overflow-hidden p-0">
+        <DrawerHeader className="sr-only">
+          <DrawerTitle>{title}</DrawerTitle>
+          <DrawerDescription>{description}</DrawerDescription>
+        </DrawerHeader>
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DrawerContent>
+    </Drawer>
+    )
+  }
+
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
@@ -181,4 +232,5 @@ export {
   CommandItem,
   CommandShortcut,
   CommandSeparator,
+  CommandResponsiveDialog
 }

--- a/src/modules/dashboard/ui/components/dashboard-command.tsx
+++ b/src/modules/dashboard/ui/components/dashboard-command.tsx
@@ -1,4 +1,4 @@
-import { CommandDialog, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
+import { CommandResponsiveDialog, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import { Dispatch, SetStateAction } from "react";
 
 interface Props {
@@ -8,7 +8,7 @@ interface Props {
 
 export const DashboardCommand = ({open, setOpen}: Props) => {
     return (
-        <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandResponsiveDialog open={open} onOpenChange={setOpen}>
             <CommandInput
                 placeholder="Find a meeting or agent"
             />
@@ -17,6 +17,6 @@ export const DashboardCommand = ({open, setOpen}: Props) => {
                     Test
                 </CommandItem>
             </CommandList>
-        </CommandDialog>
+        </CommandResponsiveDialog>
     )
 }


### PR DESCRIPTION
## Summary by Sourcery

Add responsive dialog components that switch between Drawer on mobile and Dialog on desktop, update dashboard to use the new responsive dialog, and include base cursor pointer styling.

New Features:
- Add CommandResponsiveDialog component to render a Drawer on mobile and a Dialog on desktop
- Introduce a generic ResponsiveDialog component for shared responsive dialog behavior

Enhancements:
- Switch DashboardCommand to use CommandResponsiveDialog instead of CommandDialog

Chores:
- Add base CSS rule to apply cursor pointer on button and role=button elements when enabled