### PR TITLE
12:agents-data-table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.76.1",
+        "@tanstack/react-table": "^8.21.3",
         "@trpc/client": "^11.1.2",
         "@trpc/server": "^11.1.2",
         "@trpc/tanstack-react-query": "^11.1.2",
@@ -4196,6 +4197,39 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@trpc/client": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.76.1",
+    "@tanstack/react-table": "^8.21.3",
     "@trpc/client": "^11.1.2",
     "@trpc/server": "^11.1.2",
     "@trpc/tanstack-react-query": "^11.1.2",

--- a/public/empty.svg
+++ b/public/empty.svg
@@ -1,0 +1,40 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import Image from "next/image";
+
+interface Props {
+    title: string;
+    description: string
+}
+
+export const EmptyState = ({
+    title,
+    description
+}: Props) => {
+    return (
+        <div className="flex flex-col items-center justify-center">
+            <Image src="/empty.svg" alt="Empty" width={240} height={240} />
+            <div className="flex flex-col gap-y-6 max-w-md mx-auto text-center">
+                <h6 className="text-lg font-medium">{title}</h6>
+                <p className="text-sm text-muted-foreground">
+                    {description}
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -2,12 +2,19 @@ import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { agentsInsertSchema } from "@/lib/zod-schemas";
 import { baseProcedure, createTRPCRouter, protectedProcedure } from "@/trpc/init";
-import { eq } from "drizzle-orm";
+import { eq, getTableColumns, sql } from "drizzle-orm";
 import z from "zod";
 
 export const agentsRouter = createTRPCRouter({
     getOne: protectedProcedure.input(z.object({ id: z.string() })).query(async ({ input }) => {
-        const [existingAgent] = await db.select().from(agents).where(eq(agents.id, input.id));
+        const [existingAgent] = await db
+        .select({
+            ...getTableColumns(agents),
+            //TODO: change to actual count
+            meetingCount: sql<number>`5`
+        })
+        .from(agents)
+        .where(eq(agents.id, input.id));
 
         return existingAgent;
     }),

--- a/src/modules/agents/ui/components/columns.tsx
+++ b/src/modules/agents/ui/components/columns.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { AgentGetOne } from "../../types"
+import { GeneratedAvatar } from "@/components/generated-avatar"
+import { CornerDownRightIcon, VideoIcon } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+
+export const columns: ColumnDef<AgentGetOne>[] = [
+  {
+    accessorKey: "name",
+    header: "Agent name",
+    cell: ({ row }) => (
+        <div className="flex flex-col gap-y-1">
+            <div className="flex items-center gap-x-4">
+                <GeneratedAvatar seed={row.original.name} variant="botttsNeutral" className="size-10" />
+                <span className="font-semibold capitalize">{row.original.name}</span>
+            </div>
+              <div className="flex items-center gap-x-2">
+                <CornerDownRightIcon className="size-3 text-muted-foreground" />
+                <span className="text-sm text-muted-foreground max-w-[200px] truncate capitalize">
+                  {row.original.instructions}
+                </span>
+              </div>
+        </div>
+    )
+  },
+  {
+    accessorKey: "meetingCount",
+    header: "Meetings",
+    cell: ({ row }) => (
+      <Badge
+        variant="outline"
+        className="flex items-center gap-x-2 [&>svg]:size-4"
+      >
+        <VideoIcon className="text-blue-700" />
+        5 meetings
+      </Badge>
+    )
+  }
+]

--- a/src/modules/agents/ui/components/data-table.tsx
+++ b/src/modules/agents/ui/components/data-table.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+} from "@/components/ui/table"
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  onRowClick?: (row: TData) => void
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  onRowClick
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return (
+    <div className="overflow-hidden rounded-lg border bg-background">
+      <Table>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                onClick={() => onRowClick?.(row.original)}
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+                className="cursor-pointer"
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} className="text-sm p-4">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-19 text-center text-muted-foreground">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/src/modules/agents/ui/views/agents-view.tsx
+++ b/src/modules/agents/ui/views/agents-view.tsx
@@ -5,13 +5,25 @@ import { LoadingState } from "@/components/loading-state";
 import { useTRPC } from "@/trpc/client";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
+import { DataTable } from "../components/data-table";
+import { columns } from "../components/columns";
+import { EmptyState } from "@/components/empty-state";
+
 export const AgentsView = () => {
     const trpc = useTRPC();
     const { data } = useSuspenseQuery(trpc.agents.getMany.queryOptions());
 
     return (
-        <div>
-            {JSON.stringify(data, null, 2)}
+        <div className="flex-1 pb-4 px-4 md:px-8 flex flex-col gap-y-4">
+            <DataTable
+                data={data} columns={columns}
+            />
+            {data.length === 0 && (
+                <EmptyState 
+                    title="Create your first Agent"
+                    description="Create an agent to join your meetings. Each agent will follow your instructions and can interact with participants during the call."
+                />
+            )}
         </div>
     )
 }
@@ -24,7 +36,7 @@ export const AgentsViewLoading = () => {
 
 export const AgentsViewError = () => {
     return (
-        <ErrorState 
+        <ErrorState
             title='Error Loading'
             description='Something went wrong'
         />


### PR DESCRIPTION
## Summary by Sourcery

Implement a structured agents list UI backed by a reusable DataTable component, enrich agent data with a placeholder meeting count, and provide custom empty and error states

New Features:
- Render agents with avatars, names, instructions, and meeting counts in a data table
- Display a custom empty state when there are no agents

Enhancements:
- Refactor AgentsView to use a reusable DataTable component instead of raw JSON
- Extend the getOne TRPC procedure to include a placeholder meetingCount via drizzle-orm
- Introduce generic DataTable and column definition components backed by @tanstack/react-table
- Add an EmptyState component and SVG asset for displaying empty views

Build:
- Add @tanstack/react-table as a dependency